### PR TITLE
Fix bug: the default value appeared in the form even though the endPointSuffix set.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .classpath
 work
 target
+/.idea

--- a/src/main/java/com/fit2cloud/jenkins/aliyunoss/AliyunOSSPublisher.java
+++ b/src/main/java/com/fit2cloud/jenkins/aliyunoss/AliyunOSSPublisher.java
@@ -168,6 +168,14 @@ public class AliyunOSSPublisher extends Publisher {
 		public void setAliyunSecretKey(String aliyunSecretKey) {
 			this.aliyunSecretKey = aliyunSecretKey;
 		}
+
+		public String getAliyunEndPointSuffix() {
+			return aliyunEndPointSuffix;
+		}
+
+		public void setAliyunEndPointSuffix(String aliyunEndPointSuffix) {
+			this.aliyunEndPointSuffix = aliyunEndPointSuffix;
+		}
 	}
 
 	@Override


### PR DESCRIPTION
When the user change the aliyunEndPointSuffix from the default value "-internal.aliyuncs.com", the new value won't fill the text box when open the system configuration panel. 
