### PR TITLE
Use jenkins-ci.org maven repository by default and set content type to the files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,20 +47,12 @@
 
 	<repositories>
 		<repository>
-			<id>fit2cloud</id>
-			<url>http://repository.fit2cloud.com/content/groups/public/</url>
-		</repository>
-		<repository>
 			<id>repo.jenkins-ci.org</id>
 			<url>http://repo.jenkins-ci.org/public/</url>
 		</repository>
 	</repositories>
 
 	<pluginRepositories>
-		<pluginRepository>
-			<id>fit2cloud</id>
-			<url>http://repository.fit2cloud.com/content/groups/public/</url>
-		</pluginRepository>
 		<pluginRepository>
 			<id>repo.jenkins-ci.org</id>
 			<url>http://repo.jenkins-ci.org/public/</url>


### PR DESCRIPTION
Thank you for the great plugin!

------------

A business company's private held maven repository is not as reliable/secured/accessible as the public ones maintained by open source community. So we had better use the jenkins-ci.org maven repository by default.

In case ones might face the issue of slow connection to jenkins-ci.org, perhaps we could introduce them to use the fit2cloud.com one in readme.md.

------------

If we are using Aliyun OSS to host our static website, it is required to set the content type of the files.
Without it, OSS would consider all files as "application/octet-stream".
As a result, when click the "refresh" button of the browser on the "xxxx/yyy.html" page, it would open a "download" dialog rather than refreshing that page.