### PR TITLE
支持了jekins2.0 的pipline 配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 FIT2CLOUD Aliyun-OSS-Plugin for Jenkins
 ====================
+在支持fork前版本功能的基础上,增加了pipline的配置
+
+    stage('Upload') {
+            steps {
+                echo 'Uploading'
+                oss bucketName: 'jar-backup', filesPath: 'web/target/*.jar', objectPrefix: '${JOB_NAME}'
+            }
+        }
+参考文档:https://jenkins.io/doc/developer/plugin-development/pipeline-integration/
+
+----------
+以下为原始文档
+----------
+
 建立统一的artifacts仓库是后续的持续部署的前提。目前，建立artifacts仓库大致有如下三种选择：
 
 1. FTP服务器：很多用户仍然在用这种方式存储Artifact
@@ -50,4 +64,3 @@ Jenkins是当前最常用的CI服务器，FIT2CLOUD Aliyun-OSS-Plugin for Jenkin
 4. mvn jdi:run 进行本地调试
 5. mvn package 打包生成hpi文件
 
-如果有问题，请联系zhimin@fit2cloud.com

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.593</version>
+		<version>1.609.1</version>
 	</parent>
 	<version>0.6</version>
 	<packaging>hpi</packaging>
@@ -42,6 +42,11 @@
 			<groupId>commons-lang</groupId>
 			<artifactId>commons-lang</artifactId>
 			<version>2.3</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>structs</artifactId>
+			<version>1.14</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.609.1</version>
+		<version>2.23</version>
 	</parent>
 	<version>0.6</version>
 	<packaging>hpi</packaging>
@@ -48,6 +48,8 @@
 			<artifactId>structs</artifactId>
 			<version>1.14</version>
 		</dependency>
+
+
 	</dependencies>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,6 @@
 			<artifactId>structs</artifactId>
 			<version>1.14</version>
 		</dependency>
-
-
 	</dependencies>
 
 	<repositories>

--- a/src/main/java/com/fit2cloud/jenkins/aliyunoss/AliyunOSSClient.java
+++ b/src/main/java/com/fit2cloud/jenkins/aliyunoss/AliyunOSSClient.java
@@ -3,8 +3,6 @@ package com.fit2cloud.jenkins.aliyunoss;
 import com.aliyun.oss.OSSClient;
 import com.aliyun.oss.model.ObjectMetadata;
 import hudson.FilePath;
-import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import org.apache.commons.lang.time.DurationFormatUtils;
@@ -16,166 +14,165 @@ import java.net.URLConnection;
 import java.util.StringTokenizer;
 
 public class AliyunOSSClient {
-	private static final String fpSeparator = ";";
+    private static final String fpSeparator = ";";
 
-	public static boolean validateAliyunAccount(
-			final String aliyunAccessKey, final String aliyunSecretKey) throws AliyunOSSException {
-		try {
-			OSSClient client = new OSSClient(aliyunAccessKey, aliyunSecretKey);
-			client.listBuckets();
-		} catch (Exception e) {
-			throw new AliyunOSSException("阿里云账号验证失败：" + e.getMessage());
-		}
-		return true;
-	}
-
-
-	public static boolean validateOSSBucket(String aliyunAccessKey,
-											String aliyunSecretKey, String bucketName) throws AliyunOSSException{
-		try {
-			OSSClient client = new OSSClient(aliyunAccessKey, aliyunSecretKey);
-			client.getBucketLocation(bucketName);
-		} catch (Exception e) {
-			throw new AliyunOSSException("验证Bucket名称失败：" + e.getMessage());
-		}
-		return true;
-	}
-
-	public static int upload(Run<?, ?> build, TaskListener listener,
-							 final String aliyunAccessKey, final String aliyunSecretKey, final String aliyunEndPointSuffix, String bucketName, String expFP, String expVP) throws AliyunOSSException {
-		OSSClient client = new OSSClient(aliyunAccessKey, aliyunSecretKey);
-		String location = client.getBucketLocation(bucketName);
-		String endpoint = "http://" + location + aliyunEndPointSuffix;
-		client = new OSSClient(endpoint, aliyunAccessKey, aliyunSecretKey);
-		int filesUploaded = 0; // Counter to track no. of files that are uploaded
-		try {
-			AbstractBuild build1 = (AbstractBuild) build;
-			FilePath workspacePath = build1.getWorkspace();
-
-			if (workspacePath == null) {
-				listener.getLogger().println("工作空间中没有任何文件.");
-				return filesUploaded;
-			}
-			StringTokenizer strTokens = new StringTokenizer(expFP, fpSeparator);
-			FilePath[] paths = null;
-
-			listener.getLogger().println("开始上传到阿里云OSS...");
-			listener.getLogger().println("上传endpoint是：" + endpoint);
-
-			while (strTokens.hasMoreElements()) {
-				String fileName = strTokens.nextToken();
-				String embeddedVP = null;
-				if (fileName != null) {
-					int embVPSepIndex = fileName.indexOf("::");
-					if (embVPSepIndex != -1) {
-						if (fileName.length() > embVPSepIndex + 1) {
-							embeddedVP = fileName.substring(embVPSepIndex + 2, fileName.length());
-							if (Utils.isNullOrEmpty(embeddedVP)) {
-								embeddedVP = null;
-							}
-							if (embeddedVP != null	&& !embeddedVP.endsWith(Utils.FWD_SLASH)) {
-								embeddedVP = embeddedVP + Utils.FWD_SLASH;
-							}
-						}
-						fileName = fileName.substring(0, embVPSepIndex);
-					}
-				}
-
-				if (Utils.isNullOrEmpty(fileName)) {
-					return filesUploaded;
-				}
-
-				FilePath fp = new FilePath(workspacePath, fileName);
-
-				if (fp.exists() && !fp.isDirectory()) {
-					paths = new FilePath[1];
-					paths[0] = fp;
-				} else {
-					paths = workspacePath.list(fileName);
-				}
-
-				if (paths.length != 0) {
-					for (FilePath src : paths) {
-						String key = "";
-						if (Utils.isNullOrEmpty(expVP)
-								&& Utils.isNullOrEmpty(embeddedVP)) {
-							key = src.getName();
-						} else {
-							String prefix = expVP;
-							if (!Utils.isNullOrEmpty(embeddedVP)) {
-								if (Utils.isNullOrEmpty(expVP)) {
-									prefix = embeddedVP;
-								} else {
-									prefix = expVP + embeddedVP;
-								}
-							}
-							key = prefix + src.getName();
-						}
-						long startTime = System.currentTimeMillis();
-						InputStream inputStream = src.read();
-						try {
-							ObjectMetadata meta = new ObjectMetadata();
-							meta.setContentLength(src.length());
-							meta.setContentType(getContentType(src));
-							listener.getLogger().println("File: " + src.getName() + ", Content Type: " + meta.getContentType());
-							client.putObject(bucketName, key, inputStream, meta);
-						} finally {
-							try {
-								inputStream.close();
-							} catch (IOException e) {
-							}
-						}
-						long endTime = System.currentTimeMillis();
-						listener.getLogger().println("Uploaded object ["+ key + "] in " + getTime(endTime - startTime));
-						listener.getLogger().println("版本下载地址:"+"http://"+bucketName+"."+location+aliyunEndPointSuffix+"/"+key);
-						filesUploaded++;
-					}
-				}else {
-					listener.getLogger().println(expFP+"下未找到Artifacts，请确认\"要上传的Artifacts\"中路径配置正确或部署包已正常生成，如pom.xml里assembly插件及配置正确。");
-				}
-			}
-		} catch (Exception e) {
-			e.printStackTrace();
-			throw new AliyunOSSException(e.getMessage(), e.getCause());
-		}
-		return filesUploaded;
-	}
-
-	public static String getTime(long timeInMills) {
-		return DurationFormatUtils.formatDuration(timeInMills, "HH:mm:ss.S") + " (HH:mm:ss.S)";
-	}
+    public static boolean validateAliyunAccount(
+            final String aliyunAccessKey, final String aliyunSecretKey) throws AliyunOSSException {
+        try {
+            OSSClient client = new OSSClient(aliyunAccessKey, aliyunSecretKey);
+            client.listBuckets();
+        } catch (Exception e) {
+            throw new AliyunOSSException("阿里云账号验证失败：" + e.getMessage());
+        }
+        return true;
+    }
 
 
-	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types
-	// support the common web file types for now
-	private static final String[] COMMON_CONTENT_TYPES = {
-			".js", 		"application/js",
-			".json", 	"application/json",
-			".svg", 	"image/svg+xml",
-			".woff", 	"application/x-font-woff",
-			".woff2", 	"application/x-font-woff",
-			".ttf", 	"application/x-font-ttf"
-	};
+    public static boolean validateOSSBucket(String aliyunAccessKey,
+                                            String aliyunSecretKey, String bucketName) throws AliyunOSSException {
+        try {
+            OSSClient client = new OSSClient(aliyunAccessKey, aliyunSecretKey);
+            client.getBucketLocation(bucketName);
+        } catch (Exception e) {
+            throw new AliyunOSSException("验证Bucket名称失败：" + e.getMessage());
+        }
+        return true;
+    }
 
-	// http://www.rgagnon.com/javadetails/java-0487.html
-	// we don't use the more robust solutions (checking magic headers) here, because the file stream might be
-	// loaded remotely, so that would be time consuming in checking, even hangs the Jenkins build in my test.
-	private static String getContentType(FilePath filePath) {
-		FileNameMap fileNameMap = URLConnection.getFileNameMap();
-		String fileName = filePath.getName();
-		String type = fileNameMap.getContentTypeFor(fileName);
+    public static int upload(Run<?, ?> run, TaskListener listener,
+                             final String aliyunAccessKey, final String aliyunSecretKey, final String aliyunEndPointSuffix, String bucketName, String expFP, String expVP, FilePath workspacePath) throws AliyunOSSException {
 
-		if (type == null) {
-			for (int i = 0; i < COMMON_CONTENT_TYPES.length; i += 2) {
-				String extension = COMMON_CONTENT_TYPES[i];
-				int beginIndex = Math.max(0, fileName.length() - extension.length());
-				if (fileName.substring(beginIndex).equals(extension)) {
-					return COMMON_CONTENT_TYPES[i + 1];
-				}
-			}
-			type = "application/octet-stream";
-		}
-		return type;
-	}
+        OSSClient client = new OSSClient(aliyunAccessKey, aliyunSecretKey);
+        String location = client.getBucketLocation(bucketName);
+        String endpoint = "http://" + location + aliyunEndPointSuffix;
+        client = new OSSClient(endpoint, aliyunAccessKey, aliyunSecretKey);
+        int filesUploaded = 0; // Counter to track no. of files that are uploaded
+        try {
+
+            if (workspacePath == null) {
+                listener.getLogger().println("工作空间中没有任何文件.");
+                return filesUploaded;
+            }
+            StringTokenizer strTokens = new StringTokenizer(expFP, fpSeparator);
+            FilePath[] paths = null;
+
+            listener.getLogger().println("开始上传到阿里云OSS...");
+            listener.getLogger().println("上传endpoint是：" + endpoint);
+
+            while (strTokens.hasMoreElements()) {
+                String fileName = strTokens.nextToken();
+                String embeddedVP = null;
+                if (fileName != null) {
+                    int embVPSepIndex = fileName.indexOf("::");
+                    if (embVPSepIndex != -1) {
+                        if (fileName.length() > embVPSepIndex + 1) {
+                            embeddedVP = fileName.substring(embVPSepIndex + 2, fileName.length());
+                            if (Utils.isNullOrEmpty(embeddedVP)) {
+                                embeddedVP = null;
+                            }
+                            if (embeddedVP != null && !embeddedVP.endsWith(Utils.FWD_SLASH)) {
+                                embeddedVP = embeddedVP + Utils.FWD_SLASH;
+                            }
+                        }
+                        fileName = fileName.substring(0, embVPSepIndex);
+                    }
+                }
+
+                if (Utils.isNullOrEmpty(fileName)) {
+                    return filesUploaded;
+                }
+
+                FilePath fp = new FilePath(workspacePath, fileName);
+
+                if (fp.exists() && !fp.isDirectory()) {
+                    paths = new FilePath[1];
+                    paths[0] = fp;
+                } else {
+                    paths = workspacePath.list(fileName);
+                }
+
+                if (paths.length != 0) {
+                    for (FilePath src : paths) {
+                        String key = "";
+                        if (Utils.isNullOrEmpty(expVP)
+                                && Utils.isNullOrEmpty(embeddedVP)) {
+                            key = src.getName();
+                        } else {
+                            String prefix = expVP;
+                            if (!Utils.isNullOrEmpty(embeddedVP)) {
+                                if (Utils.isNullOrEmpty(expVP)) {
+                                    prefix = embeddedVP;
+                                } else {
+                                    prefix = expVP + embeddedVP;
+                                }
+                            }
+                            key = prefix + src.getName();
+                        }
+                        long startTime = System.currentTimeMillis();
+                        InputStream inputStream = src.read();
+                        try {
+                            ObjectMetadata meta = new ObjectMetadata();
+                            meta.setContentLength(src.length());
+                            meta.setContentType(getContentType(src));
+                            listener.getLogger().println("File: " + src.getName() + ", Content Type: " + meta.getContentType());
+                            client.putObject(bucketName, key, inputStream, meta);
+                        } finally {
+                            try {
+                                inputStream.close();
+                            } catch (IOException e) {
+                            }
+                        }
+                        long endTime = System.currentTimeMillis();
+                        listener.getLogger().println("Uploaded object [" + key + "] in " + getTime(endTime - startTime));
+                        listener.getLogger().println("版本下载地址:" + "http://" + bucketName + "." + location + aliyunEndPointSuffix + "/" + key);
+                        filesUploaded++;
+                    }
+                } else {
+                    listener.getLogger().println(expFP + "下未找到Artifacts，请确认\"要上传的Artifacts\"中路径配置正确或部署包已正常生成，如pom.xml里assembly插件及配置正确。");
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new AliyunOSSException(e.getMessage(), e.getCause());
+        }
+        return filesUploaded;
+    }
+
+    public static String getTime(long timeInMills) {
+        return DurationFormatUtils.formatDuration(timeInMills, "HH:mm:ss.S") + " (HH:mm:ss.S)";
+    }
+
+
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types
+    // support the common web file types for now
+    private static final String[] COMMON_CONTENT_TYPES = {
+            ".js", "application/js",
+            ".json", "application/json",
+            ".svg", "image/svg+xml",
+            ".woff", "application/x-font-woff",
+            ".woff2", "application/x-font-woff",
+            ".ttf", "application/x-font-ttf"
+    };
+
+    // http://www.rgagnon.com/javadetails/java-0487.html
+    // we don't use the more robust solutions (checking magic headers) here, because the file stream might be
+    // loaded remotely, so that would be time consuming in checking, even hangs the Jenkins build in my test.
+    private static String getContentType(FilePath filePath) {
+        FileNameMap fileNameMap = URLConnection.getFileNameMap();
+        String fileName = filePath.getName();
+        String type = fileNameMap.getContentTypeFor(fileName);
+
+        if (type == null) {
+            for (int i = 0; i < COMMON_CONTENT_TYPES.length; i += 2) {
+                String extension = COMMON_CONTENT_TYPES[i];
+                int beginIndex = Math.max(0, fileName.length() - extension.length());
+                if (fileName.substring(beginIndex).equals(extension)) {
+                    return COMMON_CONTENT_TYPES[i + 1];
+                }
+            }
+            type = "application/octet-stream";
+        }
+        return type;
+    }
 
 }

--- a/src/main/java/com/fit2cloud/jenkins/aliyunoss/AliyunOSSClient.java
+++ b/src/main/java/com/fit2cloud/jenkins/aliyunoss/AliyunOSSClient.java
@@ -5,6 +5,8 @@ import com.aliyun.oss.model.ObjectMetadata;
 import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import org.apache.commons.lang.time.DurationFormatUtils;
 
 import java.io.IOException;
@@ -39,15 +41,17 @@ public class AliyunOSSClient {
 		return true;
 	}
 
-	public static int upload(AbstractBuild<?, ?> build, BuildListener listener,
-							 final String aliyunAccessKey, final String aliyunSecretKey, final String aliyunEndPointSuffix, String bucketName,String expFP,String expVP) throws AliyunOSSException {
+	public static int upload(Run<?, ?> build, TaskListener listener,
+							 final String aliyunAccessKey, final String aliyunSecretKey, final String aliyunEndPointSuffix, String bucketName, String expFP, String expVP) throws AliyunOSSException {
 		OSSClient client = new OSSClient(aliyunAccessKey, aliyunSecretKey);
 		String location = client.getBucketLocation(bucketName);
 		String endpoint = "http://" + location + aliyunEndPointSuffix;
 		client = new OSSClient(endpoint, aliyunAccessKey, aliyunSecretKey);
 		int filesUploaded = 0; // Counter to track no. of files that are uploaded
 		try {
-			FilePath workspacePath = build.getWorkspace();
+			AbstractBuild build1 = (AbstractBuild) build;
+			FilePath workspacePath = build1.getWorkspace();
+
 			if (workspacePath == null) {
 				listener.getLogger().println("工作空间中没有任何文件.");
 				return filesUploaded;

--- a/src/main/java/com/fit2cloud/jenkins/aliyunoss/AliyunOSSPublisher.java
+++ b/src/main/java/com/fit2cloud/jenkins/aliyunoss/AliyunOSSPublisher.java
@@ -19,6 +19,7 @@ import javax.servlet.ServletException;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -70,7 +71,7 @@ public class AliyunOSSPublisher extends Publisher {
 
 		return (DescriptorImpl) super.getDescriptor();
 	}
-
+	@Symbol("oss")
 	@Extension
 	public static final class DescriptorImpl extends
 			BuildStepDescriptor<Publisher> {

--- a/src/main/java/com/fit2cloud/jenkins/aliyunoss/AliyunOSSPublisher.java
+++ b/src/main/java/com/fit2cloud/jenkins/aliyunoss/AliyunOSSPublisher.java
@@ -3,225 +3,218 @@ package com.fit2cloud.jenkins.aliyunoss;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.model.*;
+import hudson.model.AbstractProject;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
-import hudson.tasks.Builder;
 import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
-
-import java.io.IOException;
-import java.io.PrintStream;
-
-import javax.annotation.Nonnull;
-import javax.servlet.ServletException;
-
 import jenkins.tasks.SimpleBuildStep;
-import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
-
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
-public class AliyunOSSPublisher extends Builder implements SimpleBuildStep {
+import javax.annotation.Nonnull;
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.io.PrintStream;
 
-	private PrintStream logger;
-	String bucketName;
-	String filesPath;
-	String objectPrefix;
-	
-	public String getBucketName() {
-		return bucketName;
-	}
+public class AliyunOSSPublisher extends Publisher implements SimpleBuildStep {
 
-	public void setBucketName(String bucketName) {
-		this.bucketName = bucketName;
-	}
+    private PrintStream logger;
+    String bucketName;
+    String filesPath;
+    String objectPrefix;
 
-	public String getFilesPath() {
-		return filesPath;
-	}
+    public String getBucketName() {
+        return bucketName;
+    }
 
-	public void setFilesPath(String filesPath) {
-		this.filesPath = filesPath;
-	}
+    public void setBucketName(String bucketName) {
+        this.bucketName = bucketName;
+    }
 
-	public String getObjectPrefix() {
-		return objectPrefix;
-	}
+    public String getFilesPath() {
+        return filesPath;
+    }
 
-	public void setObjectPrefix(String objectPrefix) {
-		this.objectPrefix = objectPrefix;
-	}
+    public void setFilesPath(String filesPath) {
+        this.filesPath = filesPath;
+    }
 
-	@DataBoundConstructor
-	public AliyunOSSPublisher(final String bucketName, final String filesPath, final String objectPrefix) {
-		this.bucketName = bucketName;
-		this.filesPath = filesPath;
-		this.objectPrefix = objectPrefix;
-	}
+    public String getObjectPrefix() {
+        return objectPrefix;
+    }
 
-	public BuildStepMonitor getRequiredMonitorService() {
-		return BuildStepMonitor.STEP;
-	}
+    public void setObjectPrefix(String objectPrefix) {
+        this.objectPrefix = objectPrefix;
+    }
 
-	@Override
-	public DescriptorImpl getDescriptor() {
+    @DataBoundConstructor
+    public AliyunOSSPublisher(final String bucketName, final String filesPath, final String objectPrefix) {
+        this.bucketName = bucketName;
+        this.filesPath = filesPath;
+        this.objectPrefix = objectPrefix;
+    }
 
-		return (DescriptorImpl) super.getDescriptor();
-	}
+    public BuildStepMonitor getRequiredMonitorService() {
+        return BuildStepMonitor.STEP;
+    }
 
+    @Override
+    public DescriptorImpl getDescriptor() {
 
-
-	@Symbol("oss")
-	@Extension
-	public static final class DescriptorImpl extends
-			BuildStepDescriptor<Builder> {
-
-		private String aliyunAccessKey;
-		private String aliyunSecretKey;
-		private String aliyunEndPointSuffix;
-
-		public DescriptorImpl() {
-			super(AliyunOSSPublisher.class);
-			load();
-		}
+        return (DescriptorImpl) super.getDescriptor();
+    }
 
 
-		@Override
-		public boolean isApplicable(Class<? extends AbstractProject> aClass) {
-			return true;
-		}
+    @Symbol("oss")
+    @Extension
+    public static final class DescriptorImpl extends
+            BuildStepDescriptor<Publisher> {
 
-		public String getDisplayName() {
-			return "上传Artifacts到阿里云OSS";
-		}
+        private String aliyunAccessKey;
+        private String aliyunSecretKey;
+        private String aliyunEndPointSuffix;
 
-		@Override
-		public boolean configure(StaplerRequest req, JSONObject formData)
-				throws FormException {
-			req.bindParameters(this);
-			this.aliyunAccessKey        = formData.getString("aliyunAccessKey");
-			this.aliyunSecretKey        = formData.getString("aliyunSecretKey");
-			this.aliyunEndPointSuffix   = formData.getString("aliyunEndPointSuffix");
-			save();
-			return super.configure(req, formData);
-		}
-
-		public FormValidation doCheckAccount(
-				@QueryParameter String aliyunAccessKey,
-				@QueryParameter String aliyunSecretKey,
-				@QueryParameter String aliyunEndPointSuffix) {
-			if (Utils.isNullOrEmpty(aliyunAccessKey)) {
-				return FormValidation.error("阿里云AccessKey不能为空！");
-			}
-			if (Utils.isNullOrEmpty(aliyunSecretKey)) {
-				return FormValidation.error("阿里云SecretKey不能为空！");
-			}
-			if (Utils.isNullOrEmpty(aliyunEndPointSuffix)) {
-				return FormValidation.error("阿里云EndPointSuffix不能为空！");
-			}
-			try {
-				AliyunOSSClient.validateAliyunAccount(aliyunAccessKey,
-						aliyunSecretKey);
-			} catch (Exception e) {
-				return FormValidation.error(e.getMessage());
-			}
-			return FormValidation.ok("验证阿里云帐号成功！");
-		}
-
-		public FormValidation doCheckBucket(@QueryParameter String val)
-				throws IOException, ServletException {
-			if (Utils.isNullOrEmpty(val)) {
-				return FormValidation.error("Bucket不能为空！");
-			}
-			try {
-				AliyunOSSClient.validateOSSBucket(aliyunAccessKey,
-						aliyunSecretKey, val);
-			} catch (Exception e) {
-				return FormValidation.error(e.getMessage());
-			}
-			return FormValidation.ok();
-		}
-
-		public FormValidation doCheckPath(@QueryParameter String val) {
-			if (Utils.isNullOrEmpty(val)) {
-				return FormValidation.error("Artifact路径不能为空！");
-			}
-			return FormValidation.ok();
-		}
-
-		public String getAliyunAccessKey() {
-			return aliyunAccessKey;
-		}
-
-		public void setAliyunAccessKey(String aliyunAccessKey) {
-			this.aliyunAccessKey = aliyunAccessKey;
-		}
-
-		public String getAliyunSecretKey() {
-			return aliyunSecretKey;
-		}
-
-		public void setAliyunSecretKey(String aliyunSecretKey) {
-			this.aliyunSecretKey = aliyunSecretKey;
-		}
-
-		public String getAliyunEndPointSuffix() {
-			return aliyunEndPointSuffix;
-		}
-
-		public void setAliyunEndPointSuffix(String aliyunEndPointSuffix) {
-			this.aliyunEndPointSuffix = aliyunEndPointSuffix;
-		}
-	}
+        public DescriptorImpl() {
+            super(AliyunOSSPublisher.class);
+            load();
+        }
 
 
-	@Override
-	public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath filePath, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
-		//TODO
-		this.logger = listener.getLogger();
-		final boolean buildFailed = run.getResult() == Result.FAILURE;
-		if (buildFailed) {
-			logger.println("Job构建失败,无需上传Aritfacts到阿里云OSS.");
-		}
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> aClass) {
+            return true;
+        }
 
-		// Resolve file path
-		String expFP = Utils.replaceTokens(run, listener, filesPath);
+        public String getDisplayName() {
+            return "上传Artifacts到阿里云OSS";
+        }
 
-		if (expFP != null) {
-			expFP = expFP.trim();
-		}
+        @Override
+        public boolean configure(StaplerRequest req, JSONObject formData)
+                throws FormException {
+            req.bindParameters(this);
+            this.aliyunAccessKey = formData.getString("aliyunAccessKey");
+            this.aliyunSecretKey = formData.getString("aliyunSecretKey");
+            this.aliyunEndPointSuffix = formData.getString("aliyunEndPointSuffix");
+            save();
+            return super.configure(req, formData);
+        }
 
-		// Resolve virtual path
-		String expVP = Utils.replaceTokens(run, listener, objectPrefix);
-		if (Utils.isNullOrEmpty(expVP)) {
-			expVP = null;
-		}
-		if (!Utils.isNullOrEmpty(expVP) && !expVP.endsWith(Utils.FWD_SLASH)) {
-			expVP = expVP.trim() + Utils.FWD_SLASH;
-		}
+        public FormValidation doCheckAccount(
+                @QueryParameter String aliyunAccessKey,
+                @QueryParameter String aliyunSecretKey,
+                @QueryParameter String aliyunEndPointSuffix) {
+            if (Utils.isNullOrEmpty(aliyunAccessKey)) {
+                return FormValidation.error("阿里云AccessKey不能为空！");
+            }
+            if (Utils.isNullOrEmpty(aliyunSecretKey)) {
+                return FormValidation.error("阿里云SecretKey不能为空！");
+            }
+            if (Utils.isNullOrEmpty(aliyunEndPointSuffix)) {
+                return FormValidation.error("阿里云EndPointSuffix不能为空！");
+            }
+            try {
+                AliyunOSSClient.validateAliyunAccount(aliyunAccessKey,
+                        aliyunSecretKey);
+            } catch (Exception e) {
+                return FormValidation.error(e.getMessage());
+            }
+            return FormValidation.ok("验证阿里云帐号成功！");
+        }
 
-		boolean success = false;
-		try {
-			int filesUploaded = AliyunOSSClient.upload(run, listener,
-					this.getDescriptor().aliyunAccessKey,
-					this.getDescriptor().aliyunSecretKey,
-					this.getDescriptor().aliyunEndPointSuffix,
-					bucketName, expFP, expVP);
-			if (filesUploaded > 0) {
-				listener.getLogger().println("上传Artifacts到阿里云OSS成功，上传文件个数:" + filesUploaded);
-				success = true;
-			}
+        public FormValidation doCheckBucket(@QueryParameter String val)
+                throws IOException, ServletException {
+            if (Utils.isNullOrEmpty(val)) {
+                return FormValidation.error("Bucket不能为空！");
+            }
+            try {
+                AliyunOSSClient.validateOSSBucket(aliyunAccessKey,
+                        aliyunSecretKey, val);
+            } catch (Exception e) {
+                return FormValidation.error(e.getMessage());
+            }
+            return FormValidation.ok();
+        }
 
-		} catch (Exception e) {
-			this.logger.println("上传Artifact到阿里云OSS失败，错误消息如下:");
-			this.logger.println(e.getMessage());
-			e.printStackTrace(this.logger);
-			success = false;
-		}
-	}
+        public FormValidation doCheckPath(@QueryParameter String val) {
+            if (Utils.isNullOrEmpty(val)) {
+                return FormValidation.error("Artifact路径不能为空！");
+            }
+            return FormValidation.ok();
+        }
+
+        public String getAliyunAccessKey() {
+            return aliyunAccessKey;
+        }
+
+        public void setAliyunAccessKey(String aliyunAccessKey) {
+            this.aliyunAccessKey = aliyunAccessKey;
+        }
+
+        public String getAliyunSecretKey() {
+            return aliyunSecretKey;
+        }
+
+        public void setAliyunSecretKey(String aliyunSecretKey) {
+            this.aliyunSecretKey = aliyunSecretKey;
+        }
+
+        public String getAliyunEndPointSuffix() {
+            return aliyunEndPointSuffix;
+        }
+
+        public void setAliyunEndPointSuffix(String aliyunEndPointSuffix) {
+            this.aliyunEndPointSuffix = aliyunEndPointSuffix;
+        }
+    }
+
+
+    @Override
+    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath filePath, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
+        this.logger = listener.getLogger();
+        final boolean buildFailed = run.getResult() == Result.FAILURE;
+        if (buildFailed) {
+            logger.println("Job构建失败,无需上传Aritfacts到阿里云OSS.");
+        }
+
+        // Resolve file path
+        String expFP = Utils.replaceTokens(run, listener, filesPath);
+
+        if (expFP != null) {
+            expFP = expFP.trim();
+        }
+
+        // Resolve virtual path
+        String expVP = Utils.replaceTokens(run, listener, objectPrefix);
+        if (Utils.isNullOrEmpty(expVP)) {
+            expVP = null;
+        }
+        if (!Utils.isNullOrEmpty(expVP) && !expVP.endsWith(Utils.FWD_SLASH)) {
+            expVP = expVP.trim() + Utils.FWD_SLASH;
+        }
+
+        try {
+            int filesUploaded = AliyunOSSClient.upload(run, listener,
+                    this.getDescriptor().aliyunAccessKey,
+                    this.getDescriptor().aliyunSecretKey,
+                    this.getDescriptor().aliyunEndPointSuffix,
+                    bucketName, expFP, expVP, filePath);
+            if (filesUploaded > 0) {
+                listener.getLogger().println("上传Artifacts到阿里云OSS成功，上传文件个数:" + filesUploaded);
+            }
+
+        } catch (Exception e) {
+            this.logger.println("上传Artifact到阿里云OSS失败，错误消息如下:");
+            this.logger.println(e.getMessage());
+            e.printStackTrace(this.logger);
+        }
+    }
 
 }

--- a/src/main/java/com/fit2cloud/jenkins/aliyunoss/Utils.java
+++ b/src/main/java/com/fit2cloud/jenkins/aliyunoss/Utils.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import hudson.Util;
 import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 
 
 public class Utils {
@@ -19,8 +21,8 @@ public class Utils {
 		return isValid;
 	}
 	
-	public static String replaceTokens(AbstractBuild<?, ?> build,
-			BuildListener listener, String text) throws IOException,
+	public static String replaceTokens(Run<?, ?> build,
+									   TaskListener listener, String text) throws IOException,
 			InterruptedException {
 		String newText = null;
 		if (!isNullOrEmpty(text)) {

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,3 @@
 <div>
- 	阿里云-OSS插件可以在构建后将artifact上传到阿里云OSS。
+ 	pip   阿里云-OSS插件可以在构建后将artifact上传到阿里云OSS。
 </div>


### PR DESCRIPTION
原先的插件不支持pipline部署,参考了jekins插件支持pipline操作的修改流程,[](https://jenkins.io/doc/developer/plugin-development/pipeline-integration/#build-wrappers) 
使用时可以
` stage('Upload') {
            steps {
                echo 'Uploading'
                oss bucketName: 'jar-backup', filesPath: 'web/target/*.jar', objectPrefix: '${JOB_NAME}'
            }
        }` 进行部署